### PR TITLE
Support for the binary registry API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
     steps:
       - run:
           name: "Install tools"
-          command: "apk add --update git bash"
+          command: |
+            sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories
+            apk add --update --update-cache curl git bash protobuf-dev util-linux
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.circleci/test
+++ b/.circleci/test
@@ -5,8 +5,13 @@ source "$(dirname "$0")/common.sh"
 
 msg "creating container for holding test data volumes"
 cid=$(docker create -v /data --name testdata busybox)
-trap 'docker rm $cid >/dev/null && msg "cleaned up container $cid"' EXIT
-gunzip -k test/testdata.fds.pb.gz
+
+cleanup_container() {
+  docker rm -f "$cid" >/dev/null && msg "cleaned up container $cid" || msg "failed to clean up container $cid"
+}
+trap cleanup_container EXIT
+
+gunzip -fk test/testdata.fds.pb.gz
 docker cp test/testdata.fds.pb testdata:/data
 
 msg "running a build using $image"
@@ -15,8 +20,21 @@ docker run --rm --volumes-from testdata "$image" -i /data/testdata.fds.pb -o /da
 msg "transferring output from test data volume"
 rm -rf testoutput
 docker cp testdata:/data/testoutput testoutput
+cleanup_container
 
+test_tag=proto-registry-test-$(uuidgen)
 msg "attempting to build the resulting deploy Docker image"
-docker build testoutput
+docker build -t "$test_tag" testoutput
+
+msg "starting built docker image..."
+cid=$(docker run --rm -d -p 80 "$test_tag")
+
+type_url=http://localhost:80/google.protobuf.Any
+msg "trying to fetch binary schema at $type_url"
+docker run --rm --network container:"$cid" appropriate/curl -H 'Accept: application/protobuf' "$type_url" | protoc --decode google.protobuf.Type /usr/include/google/protobuf/type.proto
+
+msg "trying to fetch HTML schema at $type_url"
+docker run --rm --network container:"$cid" appropriate/curl -H 'Accept: text/html' -i "$type_url"
+echo >&2
 
 msg "success!"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-/node_modules/
+node_modules

--- a/api-generator/main.go
+++ b/api-generator/main.go
@@ -12,6 +12,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 type output struct {
@@ -52,7 +54,7 @@ func main() {
 			log.Fatalln("no input file specified")
 		}
 		if len(outputPath) == 0 {
-			log.Fatalln("no input file specified")
+			log.Fatalln("no output file specified")
 		}
 
 		in, err := ioutil.ReadFile(inputPath)
@@ -228,7 +230,46 @@ func buildMessageOneofs(oneofs []*descriptor.OneofDescriptorProto, output []stri
 }
 
 func buildMessageOptions(options *descriptor.MessageOptions, output []*ptype.Option) ([]*ptype.Option, error) {
-	// TODO
+	if options == nil {
+		return output, nil
+	}
+
+	if options.MessageSetWireFormat != nil {
+		option, err := buildBoolOption("message_set_wire_format", *options.MessageSetWireFormat)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.NoStandardDescriptorAccessor != nil {
+		option, err := buildBoolOption("no_standard_descriptor_accessor", *options.NoStandardDescriptorAccessor)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Deprecated != nil {
+		option, err := buildBoolOption("deprecated", *options.Deprecated)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.MapEntry != nil {
+		option, err := buildBoolOption("map_entry", *options.MapEntry)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
 	return output, nil
 }
 
@@ -265,4 +306,19 @@ func buildEnumValues(values []*descriptor.EnumValueDescriptorProto, output []*pt
 func buildEnumOptions(options *descriptor.EnumOptions, output []*ptype.Option) ([]*ptype.Option, error) {
 	// TODO
 	return output, nil
+}
+
+func buildBoolOption(name string, value bool) (*ptype.Option, error) {
+	any, err := ptypes.MarshalAny(&wrappers.BoolValue{Value: value})
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ptype.Option{
+		Name:  name,
+		Value: any,
+	}
+
+	return result, nil
 }

--- a/api-generator/main.go
+++ b/api-generator/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"google.golang.org/genproto/protobuf/api"
 	"google.golang.org/genproto/protobuf/ptype"
@@ -12,29 +14,22 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"path/filepath"
+	"strings"
 )
 
 type output struct {
-	Types   []*ptype.Type   `json:"type"`
-	Enums   []*ptype.Enum   `json:"enum"`
-	Options []*ptype.Option `json:"option"`
-	Apis    []*api.Api      `json:"api"`
-}
-
-type context struct {
-	scope    string
-	fileName string
-	syntax   ptype.Syntax
+	Types []*ptype.Type
+	Enums []*ptype.Enum
+	Apis  []*api.Api
 }
 
 func main() {
 	app := cli.NewApp()
 
 	var inputPath, outputPath string
-	app.Name = "proto-type-index"
-	app.Usage = "Converts a protobuf FileDescriptorSet into Type objects"
+	app.Name = "api-generator"
+	app.Usage = "Converts a protobuf FileDescriptorSet into Type (et al) objects"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:        "input, i",
@@ -42,42 +37,37 @@ func main() {
 			Destination: &inputPath,
 		},
 		cli.StringFlag{
-			Name: "output, o",
-			Usage: "the output file pattern where '{name}' will be substituted with the " +
-				"type name, and '{kind}' will be substituted with one of 'type', 'enum', " +
-				"'option' or 'api'",
+			Name:        "output, o",
+			Usage:       "the output file pattern where '{name}' will be substituted with the type name",
 			Destination: &outputPath,
 		},
 	}
 	app.Action = func(c *cli.Context) error {
 		if len(inputPath) == 0 {
-			log.Fatalln("no input file specified")
+			return errors.Errorf("no input file specified")
 		}
 		if len(outputPath) == 0 {
-			log.Fatalln("no output file specified")
+			return errors.Errorf("no output file specified")
 		}
 
 		in, err := ioutil.ReadFile(inputPath)
 		if err != nil {
-			log.Fatalln("error reading input file:", err)
+			return errors.Wrapf(err, "error reading input file %s", inputPath)
 		}
 
 		fds := &descriptor.FileDescriptorSet{}
 		if err := proto.Unmarshal(in, fds); err != nil {
-			log.Fatalln("failed to parse file descriptor set:", err)
+			return errors.Wrapf(err, "failed to parse file descriptor set")
 		}
 
 		output := new(output)
 		if err := buildFileSetTypes(fds, output); err != nil {
-			log.Fatalln("failed to build API descriptions:", err)
+			return errors.Wrap(err, "failed to build API descriptions")
 		}
 
-		data, err := json.Marshal(output)
-		if err != nil {
-			log.Fatalln("failed to serialize result to JSON:", err)
+		if err := emit(outputPath, output); err != nil {
+			return errors.Wrapf(err, "failed to emit output to %s", outputPath)
 		}
-
-		log.Println("result:", string(data))
 
 		return nil
 	}
@@ -88,10 +78,61 @@ func main() {
 	}
 }
 
+func emit(outputPath string, output *output) error {
+	for _, ty := range output.Types {
+		typePath := strings.Replace(outputPath, "{name}", ty.Name, -1)
+		out, err := proto.Marshal(ty)
+		if err != nil {
+			return errors.Wrapf(err, "could not marshal type %s", ty.Name)
+		}
+		if err := writeData(typePath, out); err != nil {
+			return errors.Wrapf(err, "could not write type %s to %s", ty.Name, typePath)
+		}
+	}
+
+	for _, apiTy := range output.Apis {
+		typePath := strings.Replace(outputPath, "{name}", apiTy.Name, -1)
+		out, err := proto.Marshal(apiTy)
+		if err != nil {
+			return errors.Wrapf(err, "could not marshal API %s", apiTy.Name)
+		}
+		if err := writeData(typePath, out); err != nil {
+			return errors.Wrapf(err, "could not write API %s to %s", apiTy.Name, typePath)
+		}
+	}
+
+	for _, enumTy := range output.Enums {
+		typePath := strings.Replace(outputPath, "{name}", enumTy.Name, -1)
+		out, err := proto.Marshal(enumTy)
+		if err != nil {
+			return errors.Wrapf(err, "could not marshal enum %s", enumTy.Name)
+		}
+		if err := writeData(typePath, out); err != nil {
+			return errors.Wrapf(err, "could not write enum %s to %s", enumTy.Name, typePath)
+		}
+	}
+
+	return nil
+}
+
+func writeData(path string, out []byte) error {
+	dir := filepath.Dir(path)
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrapf(err, "could not create directory at %s", dir)
+	}
+
+	if err := ioutil.WriteFile(path, out, 0644); err != nil {
+		return errors.Wrapf(err, "could not write %s", path)
+	}
+
+	return nil
+}
+
 func buildFileSetTypes(fds *descriptor.FileDescriptorSet, output *output) error {
 	for _, file := range fds.File {
 		if err := buildFileTypes(file, output); err != nil {
-			return err
+			return errors.Wrapf(err, "could not process proto file %s", *file.Name)
 		}
 	}
 	return nil
@@ -100,25 +141,220 @@ func buildFileSetTypes(fds *descriptor.FileDescriptorSet, output *output) error 
 func buildFileTypes(file *descriptor.FileDescriptorProto, output *output) error {
 	syntax, err := buildSyntax(file.Syntax)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not determine file syntax")
 	}
 
 	for _, message := range file.MessageType {
-		err := buildMessageTypes(file.Package, file.Name, syntax, message, output)
+		err := buildMessageType(file.Package, file.Name, syntax, message, output)
 
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "could not process message %s", *message.Name)
 		}
 	}
 
 	for _, enum := range file.EnumType {
-		err := buildEnumTypes(file.Package, file.Name, syntax, enum, output)
+		err := buildEnumType(file.Package, file.Name, syntax, enum, output)
 
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "could not process enum %s", *enum.Name)
 		}
 	}
+
+	for _, service := range file.Service {
+		err := buildService(file.Package, file.Name, syntax, service, output)
+
+		if err != nil {
+			return errors.Wrapf(err, "could not process service %s", *service.Name)
+		}
+	}
+
+	extensions := make([]*ptype.Field, 0)
+	for _, extension := range file.Extension {
+		extensions, err = buildExtension(file.Package, file.Name, syntax, extension, extensions)
+
+		if err != nil {
+			return errors.Wrapf(err, "could not process extension %s", *extension.Name)
+		}
+	}
+	// TODO not sure how to use the extensions at this point
+
+	options := make([]*ptype.Option, 0)
+	options, err = buildFileOptions(file.Options, options)
+	if err != nil {
+		return errors.Wrap(err, "could not process file options")
+	}
+
 	return nil
+}
+
+func buildFileOptions(options *descriptor.FileOptions, output []*ptype.Option) ([]*ptype.Option, error) {
+	if options == nil {
+		return output, nil
+	}
+
+	if options.JavaPackage != nil {
+		option, err := buildStringOption("java_package", *options.JavaPackage)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.JavaOuterClassname != nil {
+		option, err := buildStringOption("java_outer_classname", *options.JavaOuterClassname)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.JavaMultipleFiles != nil {
+		option, err := buildBoolOption("java_multiple_files", *options.JavaMultipleFiles)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.JavaGenerateEqualsAndHash != nil {
+		option, err := buildBoolOption("java_generate_equals_and_hash", *options.JavaGenerateEqualsAndHash)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.JavaStringCheckUtf8 != nil {
+		option, err := buildBoolOption("java_string_check_utf8", *options.JavaStringCheckUtf8)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.OptimizeFor != nil {
+		option, err := buildInt32Option("optimize_for", int32(*options.OptimizeFor))
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.GoPackage != nil {
+		option, err := buildStringOption("go_package", *options.GoPackage)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.CcGenericServices != nil {
+		option, err := buildBoolOption("cc_generic_services", *options.CcGenericServices)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.JavaGenericServices != nil {
+		option, err := buildBoolOption("java_generic_services", *options.JavaGenericServices)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.PyGenericServices != nil {
+		option, err := buildBoolOption("py_generic_services", *options.PyGenericServices)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.PhpGenericServices != nil {
+		option, err := buildBoolOption("php_generic_services", *options.PhpGenericServices)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Deprecated != nil {
+		option, err := buildBoolOption("deprecated", *options.Deprecated)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.CcEnableArenas != nil {
+		option, err := buildBoolOption("cc_enable_arenas", *options.CcEnableArenas)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.ObjcClassPrefix != nil {
+		option, err := buildStringOption("objc_class_prefix", *options.ObjcClassPrefix)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.CsharpNamespace != nil {
+		option, err := buildStringOption("csharp_namespace", *options.CsharpNamespace)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.SwiftPrefix != nil {
+		option, err := buildStringOption("swift_prefix", *options.SwiftPrefix)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.PhpClassPrefix != nil {
+		option, err := buildStringOption("php_class_prefix", *options.PhpClassPrefix)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.PhpNamespace != nil {
+		option, err := buildStringOption("php_namespace", *options.PhpNamespace)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	return output, nil
 }
 
 func buildSyntax(syntax *string) (ptype.Syntax, error) {
@@ -135,24 +371,23 @@ func buildSyntax(syntax *string) (ptype.Syntax, error) {
 	return ptype.Syntax_SYNTAX_PROTO2, fmt.Errorf("unrecognized syntax %s", *syntax)
 }
 
-func buildMessageTypes(scope *string, fileName *string, syntax ptype.Syntax, message *descriptor.DescriptorProto, output *output) error {
-
+func buildMessageType(scope *string, fileName *string, syntax ptype.Syntax, message *descriptor.DescriptorProto, output *output) error {
 	fields := make([]*ptype.Field, 0, len(message.Field))
 	fields, err := buildMessageFields(message.Field, fields)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not process message fields")
 	}
 
 	options := make([]*ptype.Option, 0)
 	options, err = buildMessageOptions(message.Options, options)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not process message options")
 	}
 
 	oneofs := make([]string, 0, len(message.OneofDecl))
 	oneofs, err = buildMessageOneofs(message.OneofDecl, oneofs)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not process message oneofs")
 	}
 
 	name := fmt.Sprintf("%s.%s", *scope, *message.Name)
@@ -167,7 +402,9 @@ func buildMessageTypes(scope *string, fileName *string, syntax ptype.Syntax, mes
 	output.Types = append(output.Types, result)
 
 	for _, nestedMessage := range message.NestedType {
-		buildMessageTypes(&name, fileName, syntax, nestedMessage, output)
+		if err := buildMessageType(&name, fileName, syntax, nestedMessage, output); err != nil {
+			return errors.Wrapf(err, "could not process nested message %s", *nestedMessage.Name)
+		}
 	}
 
 	return nil
@@ -178,7 +415,7 @@ func buildMessageFields(fields []*descriptor.FieldDescriptorProto, output []*pty
 		result, err := buildMessageField(field)
 
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "could not process field %s", *field.Name)
 		}
 
 		output = append(output, result)
@@ -187,28 +424,38 @@ func buildMessageFields(fields []*descriptor.FieldDescriptorProto, output []*pty
 }
 
 func buildMessageField(field *descriptor.FieldDescriptorProto) (*ptype.Field, error) {
-	var oneofIndex int32 = 0
+	var oneofIndex int32
 	if field.OneofIndex != nil {
 		oneofIndex = *field.OneofIndex + 1
 	}
 
-	var typeUrl string
+	var typeURL string
 	if field.TypeName != nil {
-		typeUrl = fmt.Sprintf("type.googleapis.com/%s", *field.TypeName)
+		typeURL = fmt.Sprintf("type.googleapis.com/%s", *field.TypeName)
 	}
 
 	options := make([]*ptype.Option, 0)
 	options, err := buildFieldOptions(field.Options, options)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not process field options")
+	}
+
+	kind := ptype.Field_TYPE_UNKNOWN
+	if field.Type != nil {
+		kind = ptype.Field_Kind(*field.Type)
+	}
+
+	cardinality := ptype.Field_CARDINALITY_UNKNOWN
+	if field.Label != nil {
+		cardinality = ptype.Field_Cardinality(*field.Label)
 	}
 
 	result := &ptype.Field{
-		Kind:         ptype.Field_Kind(field.GetType()),
-		Cardinality:  ptype.Field_Cardinality(field.GetLabel()),
+		Kind:         kind,
+		Cardinality:  cardinality,
 		Number:       field.GetNumber(),
 		Name:         field.GetName(),
-		TypeUrl:      typeUrl,
+		TypeUrl:      typeURL,
 		OneofIndex:   oneofIndex,
 		Packed:       field.Options.GetPacked(),
 		Options:      options,
@@ -220,12 +467,72 @@ func buildMessageField(field *descriptor.FieldDescriptorProto) (*ptype.Field, er
 }
 
 func buildFieldOptions(options *descriptor.FieldOptions, output []*ptype.Option) ([]*ptype.Option, error) {
-	// TODO
+	if options == nil {
+		return output, nil
+	}
+
+	if options.Ctype != nil {
+		option, err := buildInt32Option("ctype", int32(*options.Ctype))
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Packed != nil {
+		option, err := buildBoolOption("packed", *options.Packed)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Jstype != nil {
+		option, err := buildInt32Option("jstype", int32(*options.Jstype))
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Lazy != nil {
+		option, err := buildBoolOption("lazy", *options.Lazy)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Deprecated != nil {
+		option, err := buildBoolOption("deprecated", *options.Deprecated)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Weak != nil {
+		option, err := buildBoolOption("weak", *options.Weak)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
 	return output, nil
 }
 
 func buildMessageOneofs(oneofs []*descriptor.OneofDescriptorProto, output []string) ([]string, error) {
-	// TODO
+	for _, oneof := range oneofs {
+		output = append(output, *oneof.Name)
+	}
+
 	return output, nil
 }
 
@@ -273,7 +580,7 @@ func buildMessageOptions(options *descriptor.MessageOptions, output []*ptype.Opt
 	return output, nil
 }
 
-func buildEnumTypes(scope *string, fileName *string, syntax ptype.Syntax, enum *descriptor.EnumDescriptorProto, output *output) error {
+func buildEnumType(scope *string, fileName *string, syntax ptype.Syntax, enum *descriptor.EnumDescriptorProto, output *output) error {
 	values := make([]*ptype.EnumValue, 0, len(enum.Value))
 	values, err := buildEnumValues(enum.Value, values)
 	if err != nil {
@@ -299,17 +606,125 @@ func buildEnumTypes(scope *string, fileName *string, syntax ptype.Syntax, enum *
 }
 
 func buildEnumValues(values []*descriptor.EnumValueDescriptorProto, output []*ptype.EnumValue) ([]*ptype.EnumValue, error) {
-	// TODO
+	for _, value := range values {
+		result, err := buildEnumValue(value)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not process enum value %s", *value.Name)
+		}
+
+		output = append(output, result)
+	}
+	return output, nil
+}
+
+func buildEnumValue(value *descriptor.EnumValueDescriptorProto) (*ptype.EnumValue, error) {
+	options := make([]*ptype.Option, 0)
+	options, err := buildEnumValueOptions(value.Options, options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ptype.EnumValue{
+		Name:    value.GetName(),
+		Number:  value.GetNumber(),
+		Options: options,
+	}
+
+	return result, nil
+}
+
+func buildEnumValueOptions(options *descriptor.EnumValueOptions, output []*ptype.Option) ([]*ptype.Option, error) {
+	if options == nil {
+		return output, nil
+	}
+
+	if options.Deprecated != nil {
+		option, err := buildBoolOption("deprecated", *options.Deprecated)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
 	return output, nil
 }
 
 func buildEnumOptions(options *descriptor.EnumOptions, output []*ptype.Option) ([]*ptype.Option, error) {
-	// TODO
+	if options == nil {
+		return output, nil
+	}
+
+	if options.AllowAlias != nil {
+		option, err := buildBoolOption("allow_alias", *options.AllowAlias)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
+	if options.Deprecated != nil {
+		option, err := buildBoolOption("deprecated", *options.Deprecated)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, option)
+	}
+
 	return output, nil
+}
+
+func buildExtension(scope *string, filename *string, syntax ptype.Syntax, extension *descriptor.FieldDescriptorProto, output []*ptype.Field) ([]*ptype.Field, error) {
+	field, err := buildMessageField(extension)
+	if err != nil {
+		return nil, err
+	}
+
+	output = append(output, field)
+
+	return output, nil
+}
+
+func buildService(scope *string, filename *string, syntax ptype.Syntax, service *descriptor.ServiceDescriptorProto, output *output) error {
+	// TODO
+	return nil
 }
 
 func buildBoolOption(name string, value bool) (*ptype.Option, error) {
 	any, err := ptypes.MarshalAny(&wrappers.BoolValue{Value: value})
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ptype.Option{
+		Name:  name,
+		Value: any,
+	}
+
+	return result, nil
+}
+
+func buildInt32Option(name string, value int32) (*ptype.Option, error) {
+	any, err := ptypes.MarshalAny(&wrappers.Int32Value{Value: value})
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ptype.Option{
+		Name:  name,
+		Value: any,
+	}
+
+	return result, nil
+}
+
+func buildStringOption(name string, value string) (*ptype.Option, error) {
+	any, err := ptypes.MarshalAny(&wrappers.StringValue{Value: value})
 
 	if err != nil {
 		return nil, err

--- a/api-generator/main.go
+++ b/api-generator/main.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/urfave/cli"
+	"google.golang.org/genproto/protobuf/api"
+	"google.golang.org/genproto/protobuf/ptype"
+	"google.golang.org/genproto/protobuf/source_context"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type output struct {
+	Types   []*ptype.Type   `json:"type"`
+	Enums   []*ptype.Enum   `json:"enum"`
+	Options []*ptype.Option `json:"option"`
+	Apis    []*api.Api      `json:"api"`
+}
+
+type context struct {
+	scope    string
+	fileName string
+	syntax   ptype.Syntax
+}
+
+func main() {
+	app := cli.NewApp()
+
+	var inputPath, outputPath string
+	app.Name = "proto-type-index"
+	app.Usage = "Converts a protobuf FileDescriptorSet into Type objects"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "input, i",
+			Usage:       "the input file containing a FileDescriptorSet",
+			Destination: &inputPath,
+		},
+		cli.StringFlag{
+			Name: "output, o",
+			Usage: "the output file pattern where '{name}' will be substituted with the " +
+				"type name, and '{kind}' will be substituted with one of 'type', 'enum', " +
+				"'option' or 'api'",
+			Destination: &outputPath,
+		},
+	}
+	app.Action = func(c *cli.Context) error {
+		if len(inputPath) == 0 {
+			log.Fatalln("no input file specified")
+		}
+		if len(outputPath) == 0 {
+			log.Fatalln("no input file specified")
+		}
+
+		in, err := ioutil.ReadFile(inputPath)
+		if err != nil {
+			log.Fatalln("error reading input file:", err)
+		}
+
+		fds := &descriptor.FileDescriptorSet{}
+		if err := proto.Unmarshal(in, fds); err != nil {
+			log.Fatalln("failed to parse file descriptor set:", err)
+		}
+
+		output := new(output)
+		if err := buildFileSetTypes(fds, output); err != nil {
+			log.Fatalln("failed to build API descriptions:", err)
+		}
+
+		data, err := json.Marshal(output)
+		if err != nil {
+			log.Fatalln("failed to serialize result to JSON:", err)
+		}
+
+		log.Println("result:", string(data))
+
+		return nil
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func buildFileSetTypes(fds *descriptor.FileDescriptorSet, output *output) error {
+	for _, file := range fds.File {
+		if err := buildFileTypes(file, output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildFileTypes(file *descriptor.FileDescriptorProto, output *output) error {
+	syntax, err := buildSyntax(file.Syntax)
+	if err != nil {
+		return err
+	}
+
+	for _, message := range file.MessageType {
+		err := buildMessageTypes(file.Package, file.Name, syntax, message, output)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, enum := range file.EnumType {
+		err := buildEnumTypes(file.Package, file.Name, syntax, enum, output)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildSyntax(syntax *string) (ptype.Syntax, error) {
+	if syntax == nil {
+		return ptype.Syntax_SYNTAX_PROTO2, nil
+	}
+
+	switch *syntax {
+	case "proto2":
+		return ptype.Syntax_SYNTAX_PROTO2, nil
+	case "proto3":
+		return ptype.Syntax_SYNTAX_PROTO3, nil
+	}
+	return ptype.Syntax_SYNTAX_PROTO2, fmt.Errorf("unrecognized syntax %s", *syntax)
+}
+
+func buildMessageTypes(scope *string, fileName *string, syntax ptype.Syntax, message *descriptor.DescriptorProto, output *output) error {
+
+	fields := make([]*ptype.Field, 0, len(message.Field))
+	fields, err := buildMessageFields(message.Field, fields)
+	if err != nil {
+		return err
+	}
+
+	options := make([]*ptype.Option, 0)
+	options, err = buildMessageOptions(message.Options, options)
+	if err != nil {
+		return err
+	}
+
+	oneofs := make([]string, 0, len(message.OneofDecl))
+	oneofs, err = buildMessageOneofs(message.OneofDecl, oneofs)
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("%s.%s", *scope, *message.Name)
+	result := &ptype.Type{
+		Name:          name,
+		Fields:        fields,
+		Oneofs:        oneofs,
+		Options:       options,
+		SourceContext: &source_context.SourceContext{FileName: *fileName},
+		Syntax:        syntax,
+	}
+	output.Types = append(output.Types, result)
+
+	for _, nestedMessage := range message.NestedType {
+		buildMessageTypes(&name, fileName, syntax, nestedMessage, output)
+	}
+
+	return nil
+}
+
+func buildMessageFields(fields []*descriptor.FieldDescriptorProto, output []*ptype.Field) ([]*ptype.Field, error) {
+	for _, field := range fields {
+		result, err := buildMessageField(field)
+
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, result)
+	}
+	return output, nil
+}
+
+func buildMessageField(field *descriptor.FieldDescriptorProto) (*ptype.Field, error) {
+	var oneofIndex int32 = 0
+	if field.OneofIndex != nil {
+		oneofIndex = *field.OneofIndex + 1
+	}
+
+	var typeUrl string
+	if field.TypeName != nil {
+		typeUrl = fmt.Sprintf("type.googleapis.com/%s", *field.TypeName)
+	}
+
+	options := make([]*ptype.Option, 0)
+	options, err := buildFieldOptions(field.Options, options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ptype.Field{
+		Kind:         ptype.Field_Kind(field.GetType()),
+		Cardinality:  ptype.Field_Cardinality(field.GetLabel()),
+		Number:       field.GetNumber(),
+		Name:         field.GetName(),
+		TypeUrl:      typeUrl,
+		OneofIndex:   oneofIndex,
+		Packed:       field.Options.GetPacked(),
+		Options:      options,
+		JsonName:     field.GetJsonName(),
+		DefaultValue: field.GetDefaultValue(),
+	}
+
+	return result, nil
+}
+
+func buildFieldOptions(options *descriptor.FieldOptions, output []*ptype.Option) ([]*ptype.Option, error) {
+	// TODO
+	return output, nil
+}
+
+func buildMessageOneofs(oneofs []*descriptor.OneofDescriptorProto, output []string) ([]string, error) {
+	// TODO
+	return output, nil
+}
+
+func buildMessageOptions(options *descriptor.MessageOptions, output []*ptype.Option) ([]*ptype.Option, error) {
+	// TODO
+	return output, nil
+}
+
+func buildEnumTypes(scope *string, fileName *string, syntax ptype.Syntax, enum *descriptor.EnumDescriptorProto, output *output) error {
+	values := make([]*ptype.EnumValue, 0, len(enum.Value))
+	values, err := buildEnumValues(enum.Value, values)
+	if err != nil {
+		return err
+	}
+
+	options := make([]*ptype.Option, 0)
+	options, err = buildEnumOptions(enum.Options, options)
+	if err != nil {
+		return err
+	}
+
+	result := &ptype.Enum{
+		Name:          fmt.Sprintf("%s.%s", *scope, *enum.Name),
+		Enumvalue:     values,
+		Options:       options,
+		SourceContext: &source_context.SourceContext{FileName: *fileName},
+		Syntax:        syntax,
+	}
+	output.Enums = append(output.Enums, result)
+
+	return nil
+}
+
+func buildEnumValues(values []*descriptor.EnumValueDescriptorProto, output []*ptype.EnumValue) ([]*ptype.EnumValue, error) {
+	// TODO
+	return output, nil
+}
+
+func buildEnumOptions(options *descriptor.EnumOptions, output []*ptype.Option) ([]*ptype.Option, error) {
+	// TODO
+	return output, nil
+}

--- a/builder/Dockerfile.builder
+++ b/builder/Dockerfile.builder
@@ -1,9 +1,15 @@
-FROM node:10.11
+FROM golang:1.11 AS api-generator
 
+WORKDIR /go/src/github.com/spotify/proto-registry/api-generator
+COPY api-generator/ ./
+RUN go get -d . && CGO_ENABLED=0 GOOS=linux go build -o api-generator .
+
+FROM node:10.11
 WORKDIR /home/node/app
 COPY config-overrides.js package.json tsconfig.json tslint.json yarn.lock /home/node/app/
 RUN yarn
 COPY public/ /home/node/app/public/
 COPY src/ /home/node/app/src/
+COPY --from=api-generator /go/src/github.com/spotify/proto-registry/api-generator/api-generator /home/node/app/
 COPY builder/entrypoint builder/Dockerfile.deploy builder/nginx.conf builder/_redirects /home/node/app/
 ENTRYPOINT ["/home/node/app/entrypoint"]

--- a/builder/entrypoint
+++ b/builder/entrypoint
@@ -38,6 +38,7 @@ yarn test
 yarn build
 
 mkdir -p "$registry_out/build"
+./api-generator -i src/schema/schema.pb -o "$registry_out/build/static/protobuf/{name}.pb"
 cp -r build/. "$registry_out/build/."
 cp _redirects "$registry_out/build"
 cp nginx.conf "$registry_out/nginx.conf"

--- a/builder/nginx.conf
+++ b/builder/nginx.conf
@@ -59,7 +59,6 @@ http {
 
     location ~ ^/(?!static/)(?<type>(.*))$ {
       add_header Vary "Accept";
-      add_header X-debug-message $prefix/$type$suffix;
       try_files $prefix/$type$suffix $uri /index.html =404;
     }
 

--- a/builder/nginx.conf
+++ b/builder/nginx.conf
@@ -11,7 +11,7 @@ http {
   sendfile on;
 
   types_hash_max_size 8192;
-  include       /etc/nginx/mime.types;
+  include /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
   log_not_found off;
@@ -39,28 +39,41 @@ http {
 
   server_names_hash_bucket_size 128;
 
+  types {
+    application/protobuf pb;
+  }
+
+  map $http_accept $prefix {
+    "~*/html" "";
+    default "/static/protobuf";
+  }
+
+  map $http_accept $suffix {
+    "~*/html" "";
+    default ".pb";
+  }
+
   server {
     root /var/www;
     index index.html;
 
-    location / {
-      try_files $uri $uri/ /index.html;
+    location ~ ^/(?!static/)(?<type>(.*))$ {
+      add_header Vary "Accept";
+      add_header X-debug-message $prefix/$type$suffix;
+      try_files $prefix/$type$suffix $uri /index.html =404;
     }
 
     location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
       expires 1M;
-      access_log off;
       add_header Cache-Control "public";
     }
 
     location ~* \.(?:css|js)$ {
-      try_files $uri =404;
       expires 1y;
-      access_log off;
       add_header Cache-Control "public";
     }
 
-    location ~ ^.+\..+$ {
+    location / {
       try_files $uri =404;
     }
   }

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -47,7 +47,12 @@ module.exports = (config, env) => {
 
   const workerTsRules = {
     test: /\.worker\.tsx?$/,
-    use: ['workerize-loader'].concat(tsLoader.use)
+    use: [{
+      loader: 'workerize-loader',
+      options: {
+        name: 'static/js/[name].[chunkhash:8]'
+      }
+    }].concat(tsLoader.use)
   }
   addBeforeRule(config.module.rules, tsMatcher, workerTsRules)
 


### PR DESCRIPTION
This PR aims to add support for the protobuf binary registry API, such that:

  - When getting HTTP requests that do not accept `text/html`, instead respond with a binary payload.
  - The request is a Protobuf encoded binary descriptor of type `google.protobuf.Type`, `google.protobuf.Enum`, `google.protobuf.Option` or `google.protobuf.Api`.